### PR TITLE
jake.FileList fails with absolute path

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -319,6 +319,11 @@ var fileUtils = new (function () {
       , part
       , pos = 0
       , path = p || '';
+
+    // always consider .. at the end as a folder and not a filename
+    if (/(?:^|\/|\\)\.\.$/.test(path.slice(-3))) {
+      path = path + '/';
+    }
     parts = path.split(/\\|\//);
     for (var i = 0, l = parts.length - 1; i < l; i++) {
       part = parts[i];

--- a/test/file.js
+++ b/test/file.js
@@ -117,6 +117,11 @@ tests = {
     assert.equal('./', file.basedir());
   }
 
+, 'test basedir with dot-dot path': function () {
+    var p = '..';
+    assert.equal('../', file.basedir(p));
+  }
+
 };
 
 module.exports = tests;


### PR DESCRIPTION
Hello,

I tried to use `jake.FileList` with an absolute directory and it failed when jake tried to read folders that are only accessible to root.
The reason is that `file.basedir` returns the highest possible folder instead of the deepest one. Eg. `file.basedir('/home/username/project/**')` returns `/` while it should return `/home/username/project/` which makes jake walks my entire hard-drive instead of just my project folder.

A quick search show me no usage of this method outside of jake so I guess that changing it's behavior is not too problematic (and the method add no documentation anyway).

Regards
