### PR TITLE
rmRf silently failing on readonly file in windows

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -170,7 +170,16 @@ var fileUtils = new (function () {
         _rmDir(curr);
       }
       else {
-        fs.unlinkSync(curr);
+        try {
+          fs.unlinkSync(curr);
+        } catch(e) {
+          if (e.code === 'EPERM') {
+            fs.chmodSync(curr, '0666');
+            fs.unlinkSync(curr);
+          } else {
+            throw e;
+          }
+        }
       }
     });
     fs.rmdirSync(dir);


### PR DESCRIPTION
I was using it on Macs fine for awhile and today on windows, I noticed the it was silently failing.  I added some tracing and noticed it was failing on fs.unlink.   I wrote a separate script with node shelljs and it worked.  The difference is they best effort try to chmod on unlink failure.  

rm -rf _install
remove:_install
remove:_install\working
remove:_install\working\defId
remove:_install\working\defId\repo
remove:_install\working\defId\repo.git
remove:_install\working\defId\repo.git\objects
remove:_install\working\defId\repo.git\objects\02
isFile:true
unlink!
{ [Error: EPERM, operation not permitted 'C:\Users\bryanmac\Projects\xxxx\host_install\working\defId\repo
.git\objects\02\37597b848a1890bb30ba0ff4102f8107cafdcb']
  errno: 50,
  code: 'EPERM',
  path: 'C:\Users\bryanmac\Projects\xxxx\host\_install\working\defId\repo\.git\objects\02\37
597b848a1890bb30ba0ff4102f8107cafdcb',
  syscall: 'unlink' }
