### PR TITLE
Preserve file permissions/mode with cpR

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -43,7 +43,6 @@ var logger = new (function () {
 
 var fileUtils = new (function () {
   var _copyFile
-    , _copyDir
     , _readDir
     , _rmDir
     , _watch;
@@ -89,30 +88,34 @@ var fileUtils = new (function () {
         targetDir = path.join(to, filename);
         // We don't care if the target dir already exists
         try {
-          fs.mkdirSync(targetDir, options.mode || parseInt(755, 8));
+          fs.mkdirSync(targetDir, fromStat.mode & 07777);
         }
         catch(e) {
-          if (e.code != 'EEXIST') {
+          if (e.code !== 'EEXIST') {
             throw e;
           }
         }
         for (var i = 0, ii = dirContents.length; i < ii; i++) {
-          //console.log(dirContents[i]);
-          _copyFile(path.join(from, dirContents[i]), targetDir);
+          _copyFile(path.join(from, dirContents[i]), targetDir, {preserveMode: options.preserveMode});
         }
       }
       // Copying a file
       else {
         content = fs.readFileSync(from);
-        // Copy into dir
+        var mode = fromStat.mode & 07777;
+        var targetFile = to;
+
         if (toStat.isDirectory()) {
-          //console.log('copy into dir ' + to);
-          fs.writeFileSync(path.join(to, filename), content);
+          targetFile = path.join(to, filename);
         }
-        // Overwrite file
-        else {
-          //console.log('overwriting ' + to);
-          fs.writeFileSync(to, content);
+
+        var fileExists = fs.existsSync(targetFile);
+        fs.writeFileSync(targetFile, content);
+
+        // If the file didn't already exist, use the original file mode.
+        // Otherwise, only update the mode if preserverMode is true.
+        if(!fileExists || options.preserveMode) {
+          fs.chmodSync(targetFile, mode);
         }
       }
     }
@@ -120,10 +123,6 @@ var fileUtils = new (function () {
     else {
       throw destDoesNotExistErr;
     }
-  };
-
-  _copyDir = function (from, to, opts) {
-    var createDir = opts.createDir;
   };
 
   // Return the contents of a given directory
@@ -246,13 +245,15 @@ var fileUtils = new (function () {
     @param {String} toPath The destination path to copy to
     @param {Object} opts Options to use
       @param {Boolean} [opts.silent] If false then will log the command
+      @param {Boolean} [opts.preserveMode] If target file already exists, this
+        determines whether the original file's mode is copied over. The default of
+        false mimics the behavior of the `cp` command line tool. (Default: false)
   */
   this.cpR = function (fromPath, toPath, options) {
     var from = path.normalize(fromPath)
       , to = path.normalize(toPath)
       , toStat
       , doesNotExistErr
-      , paths
       , filename
       , opts = options || {};
 

--- a/test/file.js
+++ b/test/file.js
@@ -145,6 +145,93 @@ tests = {
     file.rmRf('baz.txt', {silent: true});
   }
 
+, 'test cpR keeps file mode': function () {
+    fs.writeFileSync('bar.txt', 'w00t', {mode: 0750});
+    fs.writeFileSync('bar1.txt', 'w00t!', {mode: 0744});
+    file.cpR('bar.txt', 'baz.txt', {silent: true});
+    file.cpR('bar1.txt', 'baz1.txt', {silent: true});
+
+    assert.ok(existsSync('baz.txt'));
+    assert.ok(existsSync('baz1.txt'));
+    var bazStat = fs.statSync('baz.txt');
+    var bazStat1 = fs.statSync('baz1.txt');
+    assert.equal(0750, bazStat.mode & 07777);
+    assert.equal(0744, bazStat1.mode & 07777);
+
+    file.rmRf('bar.txt', {silent: true});
+    file.rmRf('baz.txt', {silent: true});
+    file.rmRf('bar1.txt', {silent: true});
+    file.rmRf('baz1.txt', {silent: true});
+  }
+
+, 'test cpR keeps file mode when overwriting with preserveMode': function () {
+    fs.writeFileSync('bar.txt', 'w00t', {mode: 0755});
+    fs.writeFileSync('baz.txt', 'w00t!', {mode: 0744});
+    file.cpR('bar.txt', 'baz.txt', {silent: true, preserveMode: true});
+
+    assert.ok(existsSync('baz.txt'));
+    var bazStat = fs.statSync('baz.txt');
+    assert.equal(0755, bazStat.mode & 07777);
+
+    file.rmRf('bar.txt', {silent: true});
+    file.rmRf('baz.txt', {silent: true});
+  }
+
+, 'test cpR does not keep file mode when overwriting': function () {
+    fs.writeFileSync('bar.txt', 'w00t', {mode: 0766});
+    fs.writeFileSync('baz.txt', 'w00t!', {mode: 0744});
+    file.cpR('bar.txt', 'baz.txt', {silent: true});
+
+    assert.ok(existsSync('baz.txt'));
+    var bazStat = fs.statSync('baz.txt');
+    assert.equal(0744, bazStat.mode & 07777);
+
+    file.rmRf('bar.txt', {silent: true});
+    file.rmRf('baz.txt', {silent: true});
+  }
+
+, 'test cpR copies file mode recursively': function () {
+    fs.mkdirSync('foo');
+    fs.writeFileSync('foo/bar.txt', 'w00t', {mode: 0740});
+    file.cpR('foo', 'baz', {silent: true});
+
+    assert.ok(existsSync('baz'));
+    var barStat = fs.statSync('baz/bar.txt');
+    assert.equal(0740, barStat.mode & 07777);
+
+    file.rmRf('foo');
+    file.rmRf('baz');
+  }
+
+, 'test cpR keeps file mode recursively': function () {
+    fs.mkdirSync('foo');
+    fs.writeFileSync('foo/bar.txt', 'w00t', {mode: 0740});
+    fs.mkdirSync('baz');
+    fs.mkdirSync('baz/foo');
+    fs.writeFileSync('baz/foo/bar.txt', 'w00t!', {mode: 0755});
+    file.cpR('foo', 'baz', {silent: true, preserveMode: true});
+
+    assert.ok(existsSync('baz'));
+    var barStat = fs.statSync('baz/foo/bar.txt');
+    assert.equal(0740, barStat.mode & 07777);
+
+    file.rmRf('foo');
+    file.rmRf('baz');
+  }
+
+, 'test cpR copies directory mode recursively': function () {
+    fs.mkdirSync('foo', 0755);
+    fs.mkdirSync('foo/bar', 0700);
+    file.cpR('foo', 'bar');
+
+    assert.ok(existsSync('foo'));
+    var fooBarStat = fs.statSync('bar/bar');
+    assert.equal(0700, fooBarStat.mode & 07777);
+
+    file.rmRf('foo');
+    file.rmRf('bar');
+  }
+
 , 'test readdirR': function () {
     var expected = [
           ['foo']


### PR DESCRIPTION
For new files and directories, they keep the permissions of the
originals. For files or directories that already exist, they'll
only keep the original permissions if the "preserverMode" option
is true. This mimics the behavior of the 'cp' command line tool.

Fixes #26